### PR TITLE
Append `\mdseries\upshape` to `\gitMarkFormat`

### DIFF
--- a/gitinfo2.sty
+++ b/gitinfo2.sty
@@ -74,9 +74,9 @@
 \newcommand{\gitDescribe}{(None)}
 \newcommand{\gitMarkPref}{[git]}
 \@ifpackageloaded{xcolor}{%
-    \newcommand{\gitMarkFormat}{\color{gray}\small\sffamily}%
+    \newcommand{\gitMarkFormat}{\color{gray}\small\sffamily\mdseries}%
 }{%
-    \newcommand{\gitMarkFormat}{\small\sffamily}%
+    \newcommand{\gitMarkFormat}{\small\sffamily\mdseries}%
 }
 \newcommand{\gitMark}{}
 \newcommand{\gitWrapEmail}[1]{#1}

--- a/gitinfo2.sty
+++ b/gitinfo2.sty
@@ -74,9 +74,9 @@
 \newcommand{\gitDescribe}{(None)}
 \newcommand{\gitMarkPref}{[git]}
 \@ifpackageloaded{xcolor}{%
-    \newcommand{\gitMarkFormat}{\color{gray}\small\sffamily\mdseries}%
+    \newcommand{\gitMarkFormat}{\color{gray}\small\sffamily\mdseries\upshape}%
 }{%
-    \newcommand{\gitMarkFormat}{\small\sffamily\mdseries}%
+    \newcommand{\gitMarkFormat}{\small\sffamily\mdseries\upshape}%
 }
 \newcommand{\gitMark}{}
 \newcommand{\gitWrapEmail}[1]{#1}

--- a/gitinfo2.tex
+++ b/gitinfo2.tex
@@ -671,7 +671,7 @@ For example:
     The default definition is:
 
 \begin{verbatim}
-\color{gray}\small\sffamily
+\color{gray}\small\sffamily\mdseries
 \end{verbatim}
 if the \sfit{xcolor} package is loaded; if not, \verb!! is simply omitted.
 You can tailor this by redefining \verb!\gitMarkFormat!. For example:

--- a/gitinfo2.tex
+++ b/gitinfo2.tex
@@ -673,7 +673,7 @@ For example:
 \begin{verbatim}
 \color{gray}\small\sffamily\mdseries
 \end{verbatim}
-if the \sfit{xcolor} package is loaded; if not, \verb!! is simply omitted.
+if the \sfit{xcolor} package is loaded; if not, \verb!\color{gray}! is simply omitted.
 You can tailor this by redefining \verb!\gitMarkFormat!. For example:
 
 \begin{verbatim}

--- a/gitinfo2.tex
+++ b/gitinfo2.tex
@@ -671,7 +671,7 @@ For example:
     The default definition is:
 
 \begin{verbatim}
-\color{gray}\small\sffamily\mdseries
+\color{gray}\small\sffamily\mdseries\upshape
 \end{verbatim}
 if the \sfit{xcolor} package is loaded; if not, \verb!\color{gray}! is simply omitted.
 You can tailor this by redefining \verb!\gitMarkFormat!. For example:


### PR DESCRIPTION
Otherwise, git watermark was bold on some ToC pages and italic before some theorem page break.